### PR TITLE
Autocompletion

### DIFF
--- a/bitlab/include/cli.h
+++ b/bitlab/include/cli.h
@@ -9,6 +9,7 @@
 #define CLI_DELIM " "
 #define CLI_COMMANDS_NUM (int) (sizeof(cli_commands) / sizeof(cli_command))
 #define CLI_HISTORY_FILE "cli_history.txt"
+#define CLI_PREFIX "BitLab> "
 
 /**
  * CLI command structure.
@@ -48,6 +49,8 @@ int cli_history(char** args);
  */
 int cli_clear(char** args);
 
+void print_help();
+
 /**
  * Prints CLI command help.
  *
@@ -82,6 +85,10 @@ char* cli_read_line(void);
  * @return The exit code.
  */
 int cli_exec_line(char* line);
+
+char** cli_completion(const char* text, int start, int end);
+
+char* cli_command_generator(const char* text, int state);
 
 /**
  * CLI handler thread.

--- a/bitlab/include/utils.h
+++ b/bitlab/include/utils.h
@@ -7,6 +7,8 @@
 #define TIMESTAMP_LENGTH 20
 
 void usleep(unsigned int usec);
+char* strdup(const char* str1);
+char* strndup(const char* src, size_t size);
 
 /**
  * Get the timestamp. This function is used to get the timestamp in a YYYYMMDDHHMMSS format.


### PR DESCRIPTION
This PR adds command auto-completion with Tab key. Implemented command-specific help command.

Tab rules:
- empty input prints help
- tabbing on help command lists available commands for detailed help
- in every other case only first word is auto-completed and tabbing is ignored
