### PR TITLE
Peer discovery - without peer connection

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "linux-clang-x64",
+            "configurationProvider": "ms-vscode.makefile-tools"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "libreadline",
         "lineptr",
         "peerdiscovery",
+        "sipa",
         "Uninstallation",
         "verack"
     ],
@@ -33,7 +34,9 @@
         "state.h": "c",
         "fcntl.h": "c",
         "log.h": "c",
-        "cstdlib": "c"
+        "cstdlib": "c",
+        "cli.h": "c",
+        "stdio.h": "c"
     },
     "C_Cpp.formatting": "vcFormat",
     "C_Cpp.autoAddFileAssociations": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,9 @@
         "log.h": "c",
         "cstdlib": "c",
         "cli.h": "c",
-        "stdio.h": "c"
+        "stdio.h": "c",
+        "network.h": "c",
+        "peer_queue.h": "c"
     },
     "C_Cpp.formatting": "vcFormat",
     "C_Cpp.autoAddFileAssociations": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "getdata",
         "getheaders",
         "getip",
+        "ipver",
         "libreadline",
         "lineptr",
         "peerdiscovery",
@@ -31,7 +32,8 @@
         "utils.h": "c",
         "state.h": "c",
         "fcntl.h": "c",
-        "log.h": "c"
+        "log.h": "c",
+        "cstdlib": "c"
     },
     "C_Cpp.formatting": "vcFormat",
     "C_Cpp.autoAddFileAssociations": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,8 +10,10 @@
         "getblocks",
         "getdata",
         "getheaders",
+        "getip",
         "libreadline",
         "lineptr",
+        "peerdiscovery",
         "Uninstallation",
         "verack"
     ],

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "BitLab"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.0.0
+PROJECT_NUMBER         = 0.1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ The default configuration directory is `~/.bitlab`. The configuration directory 
 - `blocks.dat`: Block list file
 - `txs.dat`: Transaction list file -->
 
+Please feel free to link logs to your working directory:
+
+```bash
+mkdir -p logs
+ln -s ~/.bitlab/logs/bitlab.log logs/bitlab.log
+ln -s ~/.bitlab/history/cli_history.txt logs/cli_history.txt
+```
+
 ## Features
 
 ### 1. Peer Discovery

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Easily find and connect with peers using various methods:
 
 - **Peer Information:**
   - Print out IP addresses of discovered peers.
-  - Optionally, perform recursive discovery to find more peers.
+  - Perform recursive discovery to find given amounts of peers.
 
 ### 2. Connection to Peers
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ ln -s ~/.bitlab/logs/bitlab.log logs/bitlab.log
 ln -s ~/.bitlab/history/cli_history.txt logs/cli_history.txt
 ```
 
+> [!NOTE]
+> Running as root will create the configuration directory in `/root/.bitlab`.
+
 ## Features
 
 ### 1. Peer Discovery

--- a/bitlab/include/cli.h
+++ b/bitlab/include/cli.h
@@ -106,6 +106,14 @@ int cli_whoami(char** args);
 int cli_get_ip(char** args);
 
 /**
+ * Prints program information.
+ *
+ * @param args The arguments passed to the function should be empty.
+ * @return The exit code.
+ */
+int cli_info(char** args);
+
+/**
  * Discovers Bitcoin peers.
  *
  * @param args The arguments passed to the function should be empty.

--- a/bitlab/include/cli.h
+++ b/bitlab/include/cli.h
@@ -9,21 +9,61 @@
 #define CLI_DELIM " "
 #define CLI_COMMANDS_NUM (int) (sizeof(cli_commands) / sizeof(cli_command))
 #define CLI_HISTORY_FILE "cli_history.txt"
-#define CLI_PREFIX "BitLab> "
+#define CLI_PREFIX "\033[38;5;220mBitLab \033[0m"
 
 /**
- * CLI command structure.
+ * CLI command structure. Note that the only uninitialized field can be the cli_command_detailed_desc.
  *
  * @param cli_command The function pointer to executed function.
  * @param cli_command_name The name of command by which it is called.
- * @param cli_command_description The description of command printed by !help.
+ * @param cli_command_description The description of command printed by "help".
+ * @param cli_command_detailed_desc The detailed description of command printed by "help <command>".
+ * @param cli_command_usage The usage of command printed on wrong parameters.
  */
 typedef struct
 {
-    int (*cli_command)(char**);
-    char* cli_command_name;
-    char* cli_command_description;
+    int (*cli_command)(char** args);
+    const char* cli_command_name;
+    const char* cli_command_brief_desc;
+    const char* cli_command_detailed_desc;
+    const char* cli_command_usage;
 } cli_command;
+
+
+
+//// PRINT FUNCTIONS ////
+
+/**
+ * Prints CLI command help.
+ */
+void print_help();
+
+/**
+ * Prints CLI command usage.
+ *
+ * @param command_name The name of the command.
+ */
+void print_usage(const char* command_name);
+
+/**
+ * Prints CLI commands.
+ */
+void print_commands();
+
+
+
+//// HISTORY FUNCTIONS ////
+
+/**
+ * Create history directory.
+ *
+ * @return The history directory.
+ */
+const char* create_history_dir();
+
+
+
+//// CLI COMMANDS ////
 
 /**
  * Exits BitLab CLI command.
@@ -58,6 +98,22 @@ int cli_echo(char** args);
 int cli_whoami(char** args);
 
 /**
+ * Gets remote IP address on an URL or host machine if no URL is provided.
+ *
+ * @param args The URL.
+ * @return The exit code.
+ */
+int cli_get_ip(char** args);
+
+/**
+ * Discovers Bitcoin peers.
+ *
+ * @param args The arguments passed to the function should be empty.
+ * @return The exit code.
+ */
+int cli_peer_discovery(char** args);
+
+/**
  * Clears CLI window.
  *
  * @param args The arguments passed to the function should be empty.
@@ -67,16 +123,15 @@ int cli_clear(char** args);
 
 /**
  * Prints CLI command help.
- */
-void print_help();
-
-/**
- * Prints CLI command help.
  *
  * @param args The arguments passed to this function should be empty.
  * @return The exit code.
  */
 int cli_help(char** args);
+
+
+
+//// LINE HANDLING FUNCTIONS ////
 
 /**
  * Gets the line from the file stream.
@@ -105,9 +160,32 @@ char* cli_read_line(void);
  */
 int cli_exec_line(char* line);
 
+
+
+//// LINE COMPLETION FUNCTIONS ////
+
+/**
+ * CLI completion function.
+ *
+ * @param text The text to complete.
+ * @param start The start index.
+ * @param end The end index.
+ * @return The completion.
+ */
 char** cli_completion(const char* text, int start, int end);
 
+/**
+ * CLI command generator.
+ *
+ * @param text The text to generate.
+ * @param state The state of the generator.
+ * @return The generated command.
+ */
 char* cli_command_generator(const char* text, int state);
+
+
+
+//// CLI HANDLER ////
 
 /**
  * CLI handler thread.
@@ -115,12 +193,5 @@ char* cli_command_generator(const char* text, int state);
  * @param arg Not used. Write dummy code for no warning.
  */
 void* handle_cli(void* arg);
-
-/**
- * Create history directory.
- *
- * @return The history directory.
- */
-const char* create_history_dir();
 
 #endif // __CLI_H

--- a/bitlab/include/cli.h
+++ b/bitlab/include/cli.h
@@ -129,6 +129,14 @@ int cli_clear(char** args);
  */
 int cli_help(char** args);
 
+/**
+ * Pings the specified IP address.
+ *
+ * @param args The IP address.
+ * @return The exit code.
+ */
+int cli_ping(char** args);
+
 
 
 //// LINE HANDLING FUNCTIONS ////

--- a/bitlab/include/file.h
+++ b/bitlab/include/file.h
@@ -1,0 +1,34 @@
+#ifndef __FILE_H
+#define __FILE_H
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * Read the file.
+ *
+ * @param filename The filename to read.
+ * @param buffer The buffer to store the file content.
+ * @param size The size of the file content.
+ */
+void read_file(const char* filename, char** buffer, size_t* size);
+
+/**
+ * Write the file.
+ *
+ * @param filename The filename to write.
+ * @param buffer The buffer to write.
+ * @param size The size of the buffer.
+ */
+void write_file(const char* filename, const char* buffer, size_t size);
+
+/**
+ * Append the file.
+ *
+ * @param filename The filename to append.
+ * @param buffer The buffer to append.
+ * @param size The size of the buffer.
+ */
+void append_file(const char* filename, const char* buffer, size_t size);
+
+#endif // __FILE_H

--- a/bitlab/include/ip.h
+++ b/bitlab/include/ip.h
@@ -1,52 +1,78 @@
 #ifndef __IP_H
 #define __IP_H
 
-
+#include <netdb.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 /**
  * Get the local IP address of the machine (e.g. 192.168.1.10).
  *
- * @param ip_address The buffer to store the IP address.
+ * @param ip_addr The buffer to store the IP address.
  */
-void get_local_ip_address(char* ip_address);
+void get_local_ip_address(char* ip_addr);
 
 /**
  * Get the remote IP address of the machine (e.g. 1.1.1.1).
  *
- * @param ip_address The buffer to store the IP address.
+ * @param ip_addr The buffer to store the IP address.
  */
-void get_remote_ip_address(char* ip_address);
+void get_remote_ip_address(char* ip_addr);
 
 /**
- * Get the IP address of the domain address (e.g. google.com).
+ * Perform lookup of given IP address by the domain address (e.g. google.com).
  *
- * @param addr The domain address.
- * @param ip_address The buffer to store the IP address.
+ * @param lookup_addr The current address to lookup.
+ * @param ip_addr The buffer to store the IP address.
  */
-void get_ip_of_address(const char* url, char* ip_address);
+void lookup_address(const char* lookup_addr, char* ip_addr);
 
 /**
- * Check if the IP address is in the private network (e.g. 192.168.1.10).
+ * Check if the IP address is in the private prefix (e.g. 192.168.1.10 is, 1.1.1.1 is not).
  *
- * @param ip_address The IP address to check.
+ * @param ip_addr The IP address to check.
  * @return 1 if the IP address is in the private network, 0 otherwise.
  */
-int is_in_private_network(const char* ip_address);
+int is_in_private_network(const char* ip_addr);
 
 /**
  * Check if the IP address is a numeric address (e.g. 1.1.1.1 is, example.com is not).
  *
- * @param ip_address The IP address to check.
+ * @param ip_addr The IP address to check.
  * @return 1 if the IP address is a numeric address, 0 otherwise.
  */
-int is_numeric_address(const char* ip_address);
+int is_numeric_address(const char* ip_addr);
 
 /**
  * Check if the IP address is a valid domain address (e.g. example.com is, example or 1.1.1.1 is not).
  *
- * @param ip_address The IP address to check.
+ * @param domain_addr The domain address to check.
  * @return 1 if the IP address is a valid domain address, 0 otherwise.
  */
-int is_valid_domain_address(const char* ip_address);
+int is_valid_domain_address(const char* domain_addr);
+
+
+
+//// Linux manual page ////
+
+struct addrinfo {
+    int              ai_flags;
+    int              ai_family;
+    int              ai_socktype;
+    int              ai_protocol;
+    socklen_t        ai_addrlen;
+    struct sockaddr* ai_addr;
+    char* ai_canonname;
+    struct addrinfo* ai_next;
+};
+
+int getaddrinfo(const char* restrict node,
+    const char* restrict service,
+    const struct addrinfo* restrict hints,
+    struct addrinfo** restrict res);
+
+void freeaddrinfo(struct addrinfo* res);
+
+const char* gai_strerror(int errcode);
 
 #endif // __IP_H

--- a/bitlab/include/ip.h
+++ b/bitlab/include/ip.h
@@ -5,6 +5,8 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#define MAX_IP_ADDR_LEN 1024
+
 /**
  * Get the local IP address of the machine (e.g. 192.168.1.10).
  *
@@ -24,8 +26,9 @@ void get_remote_ip_address(char* ip_addr);
  *
  * @param lookup_addr The current address to lookup.
  * @param ip_addr The buffer to store the IP address.
+ * @return 0 if successful, otherwise -1 or 1.
  */
-void lookup_address(const char* lookup_addr, char* ip_addr);
+int lookup_address(const char* lookup_addr, char* ip_addr);
 
 /**
  * Check if the IP address is in the private prefix (e.g. 192.168.1.10 is, 1.1.1.1 is not).

--- a/bitlab/include/ip.h
+++ b/bitlab/include/ip.h
@@ -1,0 +1,36 @@
+#ifndef __IP_H
+#define __IP_H
+
+
+
+/**
+ * Get the local IP address of the machine.
+ *
+ * @param ip_address The buffer to store the IP address.
+ */
+void get_local_ip_address(char* ip_address);
+
+/**
+ * Get the remote IP address of the machine.
+ *
+ * @param ip_address The buffer to store the IP address.
+ */
+void get_remote_ip_address(char* ip_address);
+
+/**
+ * Get the IP address of the URL.
+ *
+ * @param url The URL to get the IP address.
+ * @param ip_address The buffer to store the IP address.
+ */
+void get_ip_of_url(const char* url, char* ip_address);
+
+/**
+ * Check if the IP address is in the private network.
+ *
+ * @param ip_address The IP address to check.
+ * @return 1 if the IP address is in the private network, 0 otherwise.
+ */
+int is_in_private_network(const char* ip_address);
+
+#endif // __IP_H

--- a/bitlab/include/ip.h
+++ b/bitlab/include/ip.h
@@ -4,33 +4,49 @@
 
 
 /**
- * Get the local IP address of the machine.
+ * Get the local IP address of the machine (e.g. 192.168.1.10).
  *
  * @param ip_address The buffer to store the IP address.
  */
 void get_local_ip_address(char* ip_address);
 
 /**
- * Get the remote IP address of the machine.
+ * Get the remote IP address of the machine (e.g. 1.1.1.1).
  *
  * @param ip_address The buffer to store the IP address.
  */
 void get_remote_ip_address(char* ip_address);
 
 /**
- * Get the IP address of the URL.
+ * Get the IP address of the domain address (e.g. google.com).
  *
- * @param url The URL to get the IP address.
+ * @param addr The domain address.
  * @param ip_address The buffer to store the IP address.
  */
-void get_ip_of_url(const char* url, char* ip_address);
+void get_ip_of_address(const char* url, char* ip_address);
 
 /**
- * Check if the IP address is in the private network.
+ * Check if the IP address is in the private network (e.g. 192.168.1.10).
  *
  * @param ip_address The IP address to check.
  * @return 1 if the IP address is in the private network, 0 otherwise.
  */
 int is_in_private_network(const char* ip_address);
+
+/**
+ * Check if the IP address is a numeric address (e.g. 1.1.1.1 is, example.com is not).
+ *
+ * @param ip_address The IP address to check.
+ * @return 1 if the IP address is a numeric address, 0 otherwise.
+ */
+int is_numeric_address(const char* ip_address);
+
+/**
+ * Check if the IP address is a valid domain address (e.g. example.com is, example or 1.1.1.1 is not).
+ *
+ * @param ip_address The IP address to check.
+ * @return 1 if the IP address is a valid domain address, 0 otherwise.
+ */
+int is_valid_domain_address(const char* ip_address);
 
 #endif // __IP_H

--- a/bitlab/include/peer_discovery.h
+++ b/bitlab/include/peer_discovery.h
@@ -1,19 +1,6 @@
 #ifndef __PEER_DISCOVERY_H
 #define __PEER_DISCOVERY_H
 
-#include <stdint.h>
-#include <netinet/in.h>
-#include <pthread.h>
-
-#define MAX_PEERS 10
-
-typedef struct
-{
-    struct sockaddr_in address;
-    int port;
-    int is_active;
-} peer_info;
-
 /**
  * Initializes peer discovery based on configuration.
  */
@@ -25,15 +12,5 @@ void init_peer_discovery();
  * @param arg Not used. Write dummy code for no warning.
  */
 void* handle_peer_discovery(void* arg);
-
-/**
- * Send a "getaddr" message to a peer.
- */
-void send_getaddr_request(int socket_fd);
-
-/**
- * Process an "addr" message to update known peers.
- */
-void process_addr_message(int socket_fd);
 
 #endif

--- a/bitlab/include/peer_discovery.h
+++ b/bitlab/include/peer_discovery.h
@@ -1,0 +1,39 @@
+#ifndef __PEER_DISCOVERY_H
+#define __PEER_DISCOVERY_H
+
+#include <stdint.h>
+#include <netinet/in.h>
+#include <pthread.h>
+
+#define MAX_PEERS 10
+
+typedef struct
+{
+    struct sockaddr_in address;
+    int port;
+    int is_active;
+} peer_info;
+
+/**
+ * Initializes peer discovery based on configuration.
+ */
+void init_peer_discovery();
+
+/**
+ * Peer discovery handler thread.
+ *
+ * @param arg Not used. Write dummy code for no warning.
+ */
+void* handle_peer_discovery(void* arg);
+
+/**
+ * Send a "getaddr" message to a peer.
+ */
+void send_getaddr_request(int socket_fd);
+
+/**
+ * Process an "addr" message to update known peers.
+ */
+void process_addr_message(int socket_fd);
+
+#endif

--- a/bitlab/include/peer_queue.h
+++ b/bitlab/include/peer_queue.h
@@ -1,0 +1,55 @@
+#ifndef __PEER_QUEUE_H
+#define __PEER_QUEUE_H
+
+#define MAX_PEERS 10000
+
+#include <stdbool.h>
+#include <stddef.h>
+
+/**
+ * The peer structure used to store the peer information.
+ *
+ * @param ip The IP address of the peer.
+ * @param port The port of the peer.
+ */
+typedef struct
+{
+    char ip[256];
+    int port;
+} Peer;
+
+/**
+ * Add a peer to the queue.
+ *
+ * @param ip The IP address of the peer.
+ * @param port The port of the peer.
+ */
+void add_peer_to_queue(const char* ip, int port);
+
+/**
+ * Check if the peer queue is empty.
+ *
+ * @return True if the peer queue is empty, false otherwise.
+ */
+bool is_peer_queue_empty();
+
+/**
+ * Get a peer from the queue.
+ *
+ * @param buffer The buffer to store the peer.
+ * @param buffer_size The size of the buffer.
+ * @return True if the peer was successfully retrieved, false otherwise.
+ */
+bool get_peer_from_queue(char* buffer, size_t buffer_size);
+
+/**
+ * Clear the peer queue.
+ */
+void clear_peer_queue();
+
+/**
+ * Print the peer queue.
+ */
+void print_peer_queue();
+
+#endif // __PEER_QUEUE_H

--- a/bitlab/include/state.h
+++ b/bitlab/include/state.h
@@ -2,30 +2,115 @@
 #define __STATE_H
 
 #include <signal.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <time.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 /**
  * The program state structure used to store the state of the program.
  *
  * @param pid The process ID of the program.
  * @param start_time The start time of the program.
+ * @param started_with_parameters The flag to indicate if the program started with CLI parameters.
  * @param exit_flag The exit flag of the program.
+ * @param exit_flag_mutex The mutex to protect the exit flag.
  */
 typedef struct
 {
     pid_t pid;
     time_t start_time;
+    bool started_with_parameters;
     volatile sig_atomic_t exit_flag;
+    pthread_mutex_t exit_flag_mutex;
 } program_state;
 
-extern volatile program_state state;
+/**
+ * The program operation structure used to store the operation of the program.
+ *
+ * @param peer_discovery The peer discovery operation of the program.
+ * @param operation_mutex The mutex to protect the operation.
+ * @param peer_discovery_in_progress The peer discovery operation in progress.
+ */
+typedef struct
+{
+    bool peer_discovery;
+    bool peer_discovery_in_progress;
+    pthread_mutex_t operation_mutex;
+} program_operation;
 
-void init_program_state(volatile program_state* state);
+/**
+ * The program state used to store the state of the program.
+ */
+extern program_state state;
 
-void set_exit_flag(volatile program_state* state, sig_atomic_t flag);
+/**
+ * The program operation used to store all current operations of the program.
+ */
+extern program_operation operation;
 
-sig_atomic_t get_exit_flag(volatile program_state* state);
+/**
+ * Initialize the program state.
+ *
+ * @param state The program state to initialize.
+ */
+void init_program_state(program_state* state);
+
+/**
+ * Set the exit flag.
+ *
+ * @param flag The flag to set.
+ */
+void set_exit_flag(volatile sig_atomic_t flag);
+
+/**
+ * Get the exit flag.
+ *
+ * @return The exit flag.
+ */
+sig_atomic_t get_exit_flag();
+
+/**
+ * Mark the program as started with parameters.
+ */
+void mark_started_with_parameters();
+
+/**
+ * Destroy the program state.
+ *
+ * @param state The program state to destroy.
+ */
+void destroy_program_state(program_state* state);
+
+/**
+ * Initialize the program operation.
+ *
+ * @param operation The program operation to initialize.
+ * @return 0 if successful, otherwise 1.
+ */
+int init_program_operation(program_operation* operation);
+
+/**
+ * Set the peer discovery operation.
+ *
+ * @param value The value to set.
+ * @return 0 if successful, otherwise 1.
+ */
+int set_peer_discovery(bool value);
+
+/**
+ * Get the peer discovery operation.
+ *
+ * @return The peer discovery operation state.
+ */
+bool get_peer_discovery();
+
+/**
+ * Clear all program operations.
+ *
+ * @param operation The program operation to clear.
+ */
+void destroy_program_operation(program_operation* operation);
 
 #endif

--- a/bitlab/include/state.h
+++ b/bitlab/include/state.h
@@ -1,6 +1,12 @@
 #ifndef __STATE_H
 #define __STATE_H
 
+#define BITLAB_VERSION "0.1.0"
+
+#define PEER_DISCOVERY_DEFAULT_DAEMON false
+#define PEER_DISCOVERY_DEFAULT_HARDCODED_SEEDS false
+#define PEER_DISCOVERY_DEFAULT_DNS_LOOKUP true
+
 #include <signal.h>
 #include <stdbool.h>
 #include <unistd.h>
@@ -32,6 +38,10 @@ typedef struct
  * @param peer_discovery The peer discovery operation of the program.
  * @param peer_discovery_in_progress The peer discovery operation in progress.
  * @param peer_discovery_succeeded The peer discovery operation succeeded.
+ * @param peer_discovery_daemon The peer discovery operation as a daemon.
+ * @param peer_discovery_hardcoded_seeds The peer discovery operation with hardcoded seeds.
+ * @param peer_discovery_dns_lookup The peer discovery operation with DNS lookup.
+ * @param peer_discovery_dns_domain The peer discovery DNS domain field for custom DNS lookup.
  * @param operation_mutex The mutex to protect the operation.
  */
 typedef struct
@@ -39,6 +49,10 @@ typedef struct
     bool peer_discovery;
     bool peer_discovery_in_progress;
     bool peer_discovery_succeeded;
+    bool peer_discovery_daemon;
+    bool peer_discovery_hardcoded_seeds;
+    bool peer_discovery_dns_lookup;
+    char* peer_discovery_dns_domain;
     pthread_mutex_t operation_mutex;
 } program_operation;
 
@@ -56,6 +70,11 @@ extern program_operation operation;
  * Initialize the program state.
  */
 void init_program_state();
+
+/**
+ * Print the program state.
+ */
+void print_program_state();
 
 /**
  * Set the exit flag.
@@ -78,18 +97,15 @@ void mark_started_with_parameters();
 
 /**
  * Destroy the program state.
- *
- * @param state The program state to destroy.
  */
-void destroy_program_state(program_state* state);
+void destroy_program_state();
 
 /**
  * Initialize the program operation.
  *
- * @param operation The program operation to initialize.
  * @return 0 if successful, otherwise 1.
  */
-int init_program_operation(program_operation* operation);
+int init_program_operation();
 
 /**
  * Start the peer discovery progress. This function only starts the progress if the peer discovery operation is set.
@@ -107,9 +123,16 @@ void finish_peer_discovery_progress(bool succeeded);
  * Set the peer discovery operation. This function cannot stop the peer discovery operation if it is in progress. Use force_stop_peer_discovery instead.
  *
  * @param value The value to set.
- * @return 0 if successful, otherwise 1.
+ * @return True if successful, otherwise false.
  */
-int set_peer_discovery(bool value);
+bool set_peer_discovery(bool value);
+
+/**
+ * Force stop the peer discovery operation.
+ *
+ * @return True if successful, otherwise false.
+ */
+bool force_stop_peer_discovery();
 
 /**
  * Get the peer discovery operation.
@@ -126,10 +149,96 @@ bool get_peer_discovery();
 bool get_peer_discovery_in_progress();
 
 /**
- * Clear all program operations.
+ * Get the peer discovery succeeded state.
  *
- * @param operation The program operation to clear.
+ * @return The peer discovery succeeded state.
  */
-void destroy_program_operation(program_operation* operation);
+bool get_peer_discovery_succeeded();
+
+/**
+ * Set the peer discovery daemon state.
+ *
+ * @param value The value to set.
+ * @return True if successful, otherwise false.
+ */
+bool set_peer_discovery_daemon(bool value);
+
+/**
+ * Set the peer discovery hardcoded seeds state.
+ *
+ * @param value The value to set.
+ * @return True if successful, otherwise false.
+ */
+bool set_peer_discovery_hardcoded_seeds(bool value);
+
+/**
+ * Set the peer discovery DNS lookup state.
+ *
+ * @param value The value to set.
+ * @return True if successful, otherwise false.
+ */
+bool set_peer_discovery_dns_lookup(bool value);
+
+/**
+ * Get the peer discovery daemon state.
+ *
+ * @return The peer discovery daemon state.
+ */
+bool get_peer_discovery_daemon();
+
+/**
+ * Get the peer discovery hardcoded seeds state.
+ *
+ * @return The peer discovery hardcoded seeds state.
+ */
+bool get_peer_discovery_hardcoded_seeds();
+
+/**
+ * Get the peer discovery DNS lookup state.
+ *
+ * @return The peer discovery DNS lookup state.
+ */
+bool get_peer_discovery_dns_lookup();
+
+/**
+ * Set the peer discovery DNS domain.
+ *
+ * @param domain The domain to set.
+ * @return True if successful, otherwise false.
+ */
+bool set_peer_discovery_dns_domain(const char* domain);
+
+/**
+ * Get the peer discovery DNS domain.
+ *
+ * @return The peer discovery DNS domain.
+ */
+const char* get_peer_discovery_dns_domain();
+
+/**
+ * Clear all program operations.
+ */
+void destroy_program_operation();
+
+/**
+ * Get the program PID.
+ *
+ * @return The program PID.
+ */
+int get_pid();
+
+/**
+ * Get the program start time.
+ *
+ * @return The program start time.
+ */
+time_t get_start_time();
+
+/**
+ * Get the elapsed time since the program started.
+ *
+ * @return The elapsed time.
+ */
+int get_elapsed_time();
 
 #endif

--- a/bitlab/include/state.h
+++ b/bitlab/include/state.h
@@ -54,10 +54,8 @@ extern program_operation operation;
 
 /**
  * Initialize the program state.
- *
- * @param state The program state to initialize.
  */
-void init_program_state(program_state* state);
+void init_program_state();
 
 /**
  * Set the exit flag.

--- a/bitlab/include/state.h
+++ b/bitlab/include/state.h
@@ -30,13 +30,15 @@ typedef struct
  * The program operation structure used to store the operation of the program.
  *
  * @param peer_discovery The peer discovery operation of the program.
- * @param operation_mutex The mutex to protect the operation.
  * @param peer_discovery_in_progress The peer discovery operation in progress.
+ * @param peer_discovery_succeeded The peer discovery operation succeeded.
+ * @param operation_mutex The mutex to protect the operation.
  */
 typedef struct
 {
     bool peer_discovery;
     bool peer_discovery_in_progress;
+    bool peer_discovery_succeeded;
     pthread_mutex_t operation_mutex;
 } program_operation;
 
@@ -92,7 +94,19 @@ void destroy_program_state(program_state* state);
 int init_program_operation(program_operation* operation);
 
 /**
- * Set the peer discovery operation.
+ * Start the peer discovery progress. This function only starts the progress if the peer discovery operation is set.
+ */
+void start_peer_discovery_progress();
+
+/**
+ * Finish the peer discovery progress.
+ *
+ * @param succeeded The flag to indicate if the peer discovery operation succeeded.
+ */
+void finish_peer_discovery_progress(bool succeeded);
+
+/**
+ * Set the peer discovery operation. This function cannot stop the peer discovery operation if it is in progress. Use force_stop_peer_discovery instead.
  *
  * @param value The value to set.
  * @return 0 if successful, otherwise 1.
@@ -105,6 +119,13 @@ int set_peer_discovery(bool value);
  * @return The peer discovery operation state.
  */
 bool get_peer_discovery();
+
+/**
+ * Get the peer discovery in progress state.
+ *
+ * @return The peer discovery in progress state.
+ */
+bool get_peer_discovery_in_progress();
 
 /**
  * Clear all program operations.

--- a/bitlab/include/thread.h
+++ b/bitlab/include/thread.h
@@ -1,0 +1,9 @@
+#ifndef __THREAD_H
+#define __THREAD_H
+
+#include <stdio.h>
+#include <pthread.h>
+
+pthread_t thread_runner(void* (*start_routine)(void*), void* arg);
+
+#endif // __THREAD_H

--- a/bitlab/include/thread.h
+++ b/bitlab/include/thread.h
@@ -4,6 +4,13 @@
 #include <stdio.h>
 #include <pthread.h>
 
-pthread_t thread_runner(void* (*start_routine)(void*), void* arg);
+/**
+ * Thread runner function. This function is used to create a new thread.
+ *
+ * @param start_routine The function pointer to the start routine.
+ * @param name The name of the thread.
+ * @param arg The argument to pass to the start routine.
+ */
+pthread_t thread_runner(void* (*start_routine)(void*), const char* name, void* arg);
 
 #endif // __THREAD_H

--- a/bitlab/include/utils.h
+++ b/bitlab/include/utils.h
@@ -8,10 +8,12 @@
 #include "log.h"
 
 #define TIMESTAMP_LENGTH 20
+#define BUFFER_SIZE 8096
 
 void usleep(unsigned int usec);
 char* strdup(const char* str1);
 char* strndup(const char* src, size_t size);
+char* strtok(char* str, const char* delimiters);
 
 int fileno(FILE* __stream);
 void usleep(unsigned int usec);

--- a/bitlab/include/utils.h
+++ b/bitlab/include/utils.h
@@ -3,12 +3,24 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <time.h>
+
+#include "log.h"
 
 #define TIMESTAMP_LENGTH 20
 
 void usleep(unsigned int usec);
 char* strdup(const char* str1);
 char* strndup(const char* src, size_t size);
+
+int fileno(FILE* __stream);
+void usleep(unsigned int usec);
+
+struct tm* localtime_r(const time_t* timer, struct tm* buf);
+void flockfile(FILE* filehandle);
+void funlockfile(FILE* file);
+FILE* popen(const char* command, const char* type);
+int pclose(FILE* stream);
 
 /**
  * Get the timestamp. This function is used to get the timestamp in a YYYYMMDDHHMMSS format.
@@ -37,10 +49,17 @@ void clear_cli();
 int init_config_dir();
 
 /**
- * Guarded printf function. This function is used to lock the stdout file and print the formatted string.
+ * Guarded print function. This function is used to lock the stdout file and print the formatted string.
  *
  * @param format The format string.
  */
-void guarded_printf(const char* format, ...);
+void guarded_print(const char* format, ...);
+
+/**
+ * Guarded print line function. This function is used to lock the stdout file and print the formatted string.
+ *
+ * @param format The format string.
+ */
+void guarded_print_line(const char* format, ...);
 
 #endif // __UTILS_H

--- a/bitlab/src/bitlab.c
+++ b/bitlab/src/bitlab.c
@@ -18,12 +18,13 @@ bitlab_result run_bitlab(int argc, char* argv[])
     log_message(LOG_INFO, BITLAB_LOG, __FILE__, LOG_BITLAB_STARTED);
     init_program_state(&state);
     init_program_operation(&operation);
-    pthread_t cli_thread = thread_runner(handle_cli, NULL);
-    pthread_t peer_discovery_thread = thread_runner(handle_peer_discovery, NULL);
+    pthread_t cli_thread = thread_runner(handle_cli, "CLI", NULL);
+    pthread_t peer_discovery_thread = thread_runner(handle_peer_discovery, "Peer discovery", NULL);
 
     // execute command line arguments
     if (argc > 1 && argv != NULL)
     {
+        mark_started_with_parameters();
         int total_length = 0;
         for (int i = 1; i < argc; ++i)
             total_length += strlen(argv[i]) + 1;
@@ -40,9 +41,14 @@ bitlab_result run_bitlab(int argc, char* argv[])
                 if (i < argc - 1)
                     strcat(line, " ");
             }
+
+            if (argv[1] && strcmp(argv[1], "exit") == 0)
+                log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Starting BitLab with \"%s\" parameter", line);
+
             cli_exec_line(line);
             free(line);
         }
+        guarded_print_line("Close BitLab using \"exit\"");
     }
 
     // main loop

--- a/bitlab/src/cli.c
+++ b/bitlab/src/cli.c
@@ -294,7 +294,7 @@ int cli_get_ip(char** args)
         {
             if (is_valid_domain_address(args[0]))
             {
-                get_ip_of_address(args[0], ip_address);
+                lookup_address(args[0], ip_address);
                 guarded_print_line("IP address of %s: %s", args[0], ip_address);
             }
             else
@@ -305,9 +305,10 @@ int cli_get_ip(char** args)
             int i = 0;
             while (args[i] != NULL)
             {
+                ip_address[0] = '\0';
                 if (is_valid_domain_address(args[i]))
                 {
-                    get_ip_of_address(args[i], ip_address);
+                    lookup_address(args[i], ip_address);
                     guarded_print_line("%d: IP address of %s: %s", i + 1, args[i], ip_address);
                 }
                 else

--- a/bitlab/src/cli.c
+++ b/bitlab/src/cli.c
@@ -3,112 +3,399 @@
 #include <readline/readline.h>
 #include <readline/history.h>
 #include <errno.h>
+#include <pthread.h>
 #include <sys/stat.h>
 
 #include "state.h"
-#include "log.h"
 #include "utils.h"
+#include "ip.h"
 
+// History directory initialized in CLI thread
 static const char* cli_history_dir = NULL;
+
+// CLI mutex protecting started command-line operation to avoid mixing outputs
+pthread_mutex_t cli_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 // BitLab command array
 static cli_command cli_commands[] =
 {
-    {.cli_command = &cli_exit, .cli_command_name = "exit", .cli_command_description = "Stops the server." },
-    {.cli_command = &cli_history, .cli_command_name = "history", .cli_command_description = "Prints command history." },
-    {.cli_command = &cli_clear, .cli_command_name = "clear", .cli_command_description = "Clears CLI screen." },
-    {.cli_command = &cli_help, .cli_command_name = "help", .cli_command_description = "Prints command descriptions." },
-    {.cli_command = &cli_echo, .cli_command_name = "echo", .cli_command_description = "Echoes the input." },
-    {.cli_command = &cli_whoami, .cli_command_name = "whoami", .cli_command_description = "Prints the user name." },
+    {
+        .cli_command = &cli_clear,
+        .cli_command_name = "clear",
+        .cli_command_brief_desc = "Clears CLI screen.",
+        .cli_command_detailed_desc = " * clear - Clears the command line interface screen for better readability.",
+        .cli_command_usage = "clear"
+    },
+    {
+        .cli_command = &cli_echo,
+        .cli_command_name = "echo",
+        .cli_command_brief_desc = "Echoes the input.",
+        .cli_command_detailed_desc = " * echo - Outputs the text or arguments provided as input.",
+        .cli_command_usage = "echo [This is an example text to be echoed.]"
+    },
+    {
+        .cli_command = &cli_exit,
+        .cli_command_name = "exit",
+        .cli_command_brief_desc = "Stops the server.",
+        .cli_command_detailed_desc = " * exit - Stops the server gracefully and terminates the session.",
+        .cli_command_usage = "exit [-f | --force]"
+    },
+    {
+        .cli_command = &cli_get_ip,
+        .cli_command_name = "getip",
+        .cli_command_brief_desc = "Obtains IP address of given URL.",
+        .cli_command_detailed_desc = " * getip - Retrieves and displays the remote IP address of a specified URL or host if not specified.",
+        .cli_command_usage = "getip [URL 1] [URL 2] ..."
+    },
+    {
+        .cli_command = &cli_help,
+        .cli_command_name = "help",
+        .cli_command_brief_desc = "Prints command descriptions.",
+        .cli_command_detailed_desc = " * help - Lists all available commands with their descriptions.",
+        .cli_command_usage = "help [command]"
+    },
+    {
+        .cli_command = &cli_history,
+        .cli_command_name = "history",
+        .cli_command_brief_desc = "Prints command history.",
+        .cli_command_detailed_desc = " * history - Displays the history of all entered commands for reference.",
+        .cli_command_usage = "history"
+    },
+    {
+        .cli_command = &cli_peer_discovery,
+        .cli_command_name = "peerdiscovery",
+        .cli_command_brief_desc = "Starts peer discovery.",
+        .cli_command_detailed_desc = " * peerdiscovery - Initiates the peer discovery process (currently a work in progress).",
+        .cli_command_usage = "peerdiscovery [-d | --daemon]"
+    },
+    {
+        .cli_command = &cli_whoami,
+        .cli_command_name = "whoami",
+        .cli_command_brief_desc = "Prints basic information about user.",
+        .cli_command_detailed_desc = " * whoami - Displays username or full user information, including username, local IP, and public IP address when --full argument provided.",
+        .cli_command_usage = "whoami [-f | --full]"
+    },
 }; // do not add NULLs at the end
+
+void print_help()
+{
+    int longest_usage_length = 0;
+    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
+    {
+        int length = strlen(cli_commands[i].cli_command_usage);
+        if (length > longest_usage_length)
+            longest_usage_length = length;
+    }
+
+    int longest_description_length = 0;
+    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
+    {
+        int length = strlen(cli_commands[i].cli_command_brief_desc);
+        if (length > longest_description_length)
+            longest_description_length = length;
+    }
+
+    char* dashes_before = (char*)malloc(longest_usage_length + 1);
+    memset(dashes_before, '-', longest_usage_length);
+    dashes_before[longest_usage_length] = '\0';
+
+    char* dashes_after = (char*)malloc(longest_description_length + 1);
+    memset(dashes_after, '-', longest_description_length);
+    dashes_after[longest_description_length] = '\0';
+
+    guarded_print_line("\033[1m%-*s | %s\033[0m", longest_usage_length, "Command", "Description");
+    guarded_print_line("%s-+-%s", dashes_before, dashes_after);
+
+    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
+        guarded_print_line("%-*s | %s", longest_usage_length, cli_commands[i].cli_command_usage, cli_commands[i].cli_command_brief_desc);
+
+    free(dashes_before);
+    free(dashes_after);
+}
+
+void print_usage(const char* command_name)
+{
+    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
+    {
+        if (strcmp(command_name, cli_commands[i].cli_command_name) == 0)
+        {
+            guarded_print_line("Usage: %s", cli_commands[i].cli_command_usage);
+            return;
+        }
+    }
+}
+
+void print_commands()
+{
+    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
+        guarded_print_line("%s", cli_commands[i].cli_command_name);
+}
 
 int cli_exit(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
     if (args[0] != NULL)
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Arguments provided for exit command ignored");
+    {
+        if (strcmp(args[0], "-f") == 0 || strcmp(args[0], "--force") == 0)
+        {
+            if (args[1] != NULL)
+            {
+                log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for exit command: \"%s\"", args[1]);
+                print_usage("exit");
+                pthread_mutex_unlock(&cli_mutex);
+                return 1;
+            }
+            log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Force exiting BitLab");
+            pthread_mutex_unlock(&cli_mutex);
+            exit(0);
+        }
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for exit command: \"%s\"", args[0]);
+        print_usage("exit");
+        pthread_mutex_unlock(&cli_mutex);
+        return 1;
+    }
     log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Server shutdown requested");
-    set_exit_flag(&state, 1);
+    set_exit_flag(1);
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
 }
 
 int cli_history(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
     if (args[0] != NULL)
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Arguments provided for history command ignored");
+    {
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for history command: \"%s\"", args[0]);
+        print_usage("history");
+        pthread_mutex_unlock(&cli_mutex);
+        return 1;
+    }
     HIST_ENTRY** history_entries = history_list();
     if (history_entries)
     {
         for (int i = 0; history_entries[i] != NULL; ++i)
-            guarded_printf("%d: %s\n", i + 1, history_entries[i]->line);
+            guarded_print_line("%d: %s", i + 1, history_entries[i]->line);
     }
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
-}
-
-void print_help()
-{
-    int longest_length = 0;
-    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
-    {
-        int length = strlen(cli_commands[i].cli_command_name);
-        if (length > longest_length)
-            longest_length = length;
-    }
-    guarded_printf("\033[1m%-*s | %s\033[0m\n", longest_length, "Command", "Description");
-    guarded_printf("%.*s-+-%.*s\n", longest_length, "--------------------", 50, "--------------------------------------------------");
-    for (int i = 0; i < CLI_COMMANDS_NUM; ++i)
-        guarded_printf("%-*s | %s\n", longest_length, cli_commands[i].cli_command_name, cli_commands[i].cli_command_description);
 }
 
 int cli_help(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
     if (args[0] != NULL)
     {
-        if (strcmp(args[0], "exit") == 0)
-            guarded_printf(" * Detailed information about exit command:\n * exit - Stops the server.\n");
-        else if (strcmp(args[0], "history") == 0)
-            guarded_printf(" * Detailed information about history command:\n * history - Prints command history.\n");
-        else if (strcmp(args[0], "clear") == 0)
-            guarded_printf(" * Detailed information about clear command:\n * clear - Clears CLI screen.\n");
-        else if (strcmp(args[0], "help") == 0)
-            guarded_printf(" * Detailed information about help command:\n * help - Prints command descriptions.\n");
-        else if (strcmp(args[0], "echo") == 0)
-            guarded_printf(" * Detailed information about echo command:\n * echo - Echoes the input.\n");
-        else if (strcmp(args[0], "whoami") == 0)
-            guarded_printf(" * Detailed information about whoami command:\n * whoami - Prints the user name.\n");
-        else
-            guarded_printf(" * Detailed information not included.\n");
+        if (args[1] != NULL && args[2] == NULL)
+        {
+            log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Too many arguments for help command");
+            print_usage("help");
+            pthread_mutex_unlock(&cli_mutex);
+            return 1;
+        }
+        for (long unsigned i = 0; i < sizeof(cli_commands) / sizeof(cli_command); ++i)
+        {
+            if (strcmp(args[0], cli_commands[i].cli_command_name) == 0)
+            {
+                if (cli_commands[i].cli_command_detailed_desc)
+                    guarded_print_line(cli_commands[i].cli_command_detailed_desc);
+                else
+                    guarded_print_line(" * %s - Detailed information not included.", args[0]);
+                pthread_mutex_unlock(&cli_mutex);
+                return 0;
+            }
+        }
+        guarded_print_line(" * %s - Unknown command.", args[0]);
     }
     else
         print_help();
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
 }
 
 int cli_echo(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
     if (args[0] == NULL)
     {
         log_message(LOG_WARN, BITLAB_LOG, __FILE__, "No arguments provided for echo command");
+        print_usage("echo");
+        pthread_mutex_unlock(&cli_mutex);
         return 1;
     }
     for (int i = 0; args[i] != NULL; ++i)
-        guarded_printf("%s ", args[i]);
-    guarded_printf("\n");
+        guarded_print("%s ", args[i]);
+    guarded_print("\n");
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
 }
 
 int cli_whoami(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
+    bool full_information = false;
     if (args[0] != NULL)
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Arguments provided for whoami command ignored");
-    guarded_printf("You are %s\n", getenv("USER"));
+    {
+        if (strcmp(args[0], "-f") == 0 || strcmp(args[0], "--full") == 0)
+        {
+            if (args[1] != NULL)
+            {
+                log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for whoami command: \"%s\"", args[1]);
+                print_usage("whoami");
+                pthread_mutex_unlock(&cli_mutex);
+                return 1;
+            }
+            full_information = true;
+        }
+        else
+        {
+            log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for whoami command: \"%s\"", args[0]);
+            print_usage("whoami");
+            pthread_mutex_unlock(&cli_mutex);
+            return 1;
+        }
+    }
+
+    if (!full_information)
+        guarded_print_line("%s", getenv("USER"));
+    else
+    {
+        char ip_address[256];
+        get_local_ip_address(ip_address);
+
+        if (getenv("USER") == NULL)
+            guarded_print_line("Unknown user");
+        else if (strcmp(getenv("USER"), "root") == 0)
+            guarded_print_line("You are \033[1;31m%s\033[0m", getenv("USER"));
+        else
+            guarded_print_line("You are \033[1;34m%s\033[0m", getenv("USER"));
+
+        guarded_print_line("Local IP address: %s", ip_address);
+
+        get_remote_ip_address(ip_address);
+        guarded_print_line("Public IP address: %s", ip_address);
+    }
+
+    pthread_mutex_unlock(&cli_mutex);
+    return 0;
+}
+
+int cli_get_ip(char** args)
+{
+    pthread_mutex_lock(&cli_mutex);
+    char ip_address[256];
+    if (args[0] == NULL)
+    {
+        get_remote_ip_address(ip_address);
+        guarded_print_line("Public IP address: %s", ip_address);
+    }
+    else
+    {
+        if (args[0] != NULL && args[1] == NULL)
+        {
+            if (is_valid_domain_address(args[0]))
+            {
+                get_ip_of_address(args[0], ip_address);
+                guarded_print_line("IP address of %s: %s", args[0], ip_address);
+            }
+            else
+                guarded_print_line("Invalid domain address: %s", args[0]);
+        }
+        else
+        {
+            int i = 0;
+            while (args[i] != NULL)
+            {
+                if (is_valid_domain_address(args[i]))
+                {
+                    get_ip_of_address(args[i], ip_address);
+                    guarded_print_line("%d: IP address of %s: %s", i + 1, args[i], ip_address);
+                }
+                else
+                    guarded_print_line("%d: Invalid domain address: %s", i + 1, args[i]);
+                i++;
+            }
+        }
+    }
+    pthread_mutex_unlock(&cli_mutex);
+    return 0;
+}
+
+int cli_peer_discovery(char** args)
+{
+    pthread_mutex_lock(&cli_mutex);
+    bool daemon = false;
+
+    if (args[0] != NULL)
+    {
+        for (int i = 0; args[i] != NULL; ++i)
+        {
+            if (strcmp(args[i], "-d") == 0 || strcmp(args[i], "--daemon") == 0)
+                daemon = true;
+            else
+            {
+                log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for peerdiscovery command: %s", args[i]);
+                print_usage("peerdiscovery");
+                pthread_mutex_unlock(&cli_mutex);
+                return 1;
+            }
+        }
+    }
+
+    if (get_peer_discovery())
+    {
+        if (daemon)
+        {
+            log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer discovery already in progress");
+            guarded_print_line("Peer discovery already in progress. Use \"peerdiscovery\" to check results later or \"info\" to see the status.");
+            pthread_mutex_unlock(&cli_mutex);
+            return 1;
+        }
+        else // wait for peer discovery to finish
+        {
+            guarded_print_line("Connected to peer discovery daemon. Waiting for results...");
+            while (get_peer_discovery())
+                usleep(100000); // 100 ms
+        }
+    }
+    else
+    {
+        // [ ] Break if results are already set
+
+        set_peer_discovery(true);
+
+        if (daemon)
+        {
+            log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Peer discovery in background");
+            guarded_print_line("Peer discovery started as daemon. Use \"peerdiscovery\" to check results or \"info\" to see the status.");
+            pthread_mutex_unlock(&cli_mutex);
+            return 0;
+        }
+        else // wait for peer discovery to finish
+        {
+            guarded_print_line("Peer discovery started. Waiting for results...");
+            while (get_peer_discovery())
+                usleep(100000); // 100 ms
+        }
+    }
+
+    // [ ] Add peer discovery results
+    
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
 }
 
 int cli_clear(char** args)
 {
+    pthread_mutex_lock(&cli_mutex);
     if (args[0] != NULL)
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Arguments provided for clear command ignored");
+    {
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Unknown argument for clear command: %s", args[0]);
+        print_usage("clear");
+        pthread_mutex_unlock(&cli_mutex);
+        return 1;
+    }
     clear_cli();
+    pthread_mutex_unlock(&cli_mutex);
     return 0;
 }
 
@@ -153,9 +440,11 @@ int cli_get_line(char** lineptr, size_t* n, FILE* stream)
 
 char* cli_read_line(void)
 {
+    pthread_mutex_lock(&cli_mutex);
     char* line = readline(CLI_PREFIX);
     if (line && *line)
         add_history(line);
+    pthread_mutex_unlock(&cli_mutex);
     return line;
 }
 
@@ -214,7 +503,7 @@ int cli_exec_line(char* line)
             return result;
         }
     }
-    guarded_printf("Command not found! Type \"help\" to see available commands.\n");
+    guarded_print_line("Command not found! Type \"help\" to see available commands.");
     log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Command not found: %s", command);
     free(tokens);
     return 1;
@@ -231,9 +520,9 @@ char** cli_completion(const char* text, int start, int end)
     // print help for empty input
     if (strlen(line) == 0)
     {
-        putchar('\n');
+        guarded_print("\n");
         print_help();
-        guarded_printf(CLI_PREFIX);
+        guarded_print(CLI_PREFIX);
         return NULL;
     }
 
@@ -243,15 +532,20 @@ char** cli_completion(const char* text, int start, int end)
             spaces++;
 
     // check if the input starts with "help" and allow for one space
-    if (((strncmp(line, "help", 4) == 0) && (spaces <= 1)) || (spaces <= 0))
+    if (((strncmp(line, "help", 4) == 0) && spaces <= 1))
         return rl_completion_matches(text, cli_command_generator);
+
+    // complete first word
+    if (spaces == 0)
+        return rl_completion_matches(text, cli_command_generator);
+
     return NULL;
 }
 
 char* cli_command_generator(const char* text, int state)
 {
     static int list_index, len;
-    char* name;
+    const char* name;
     if (!state)
     {
         list_index = 0;
@@ -290,7 +584,7 @@ void* handle_cli(void* arg)
     rl_attempted_completion_function = cli_completion;
     // [ ] Find setting to disable inputting space after tabbing
 
-    while (!get_exit_flag(&state))
+    while (!get_exit_flag())
     {
         line = cli_read_line();
         if (line && *line)

--- a/bitlab/src/cli.c
+++ b/bitlab/src/cli.c
@@ -659,7 +659,8 @@ void* handle_cli(void* arg)
     rl_completion_append_character = '\0';
     rl_attempted_completion_over = 1;
     rl_attempted_completion_function = cli_completion;
-    // [ ] Find setting to disable inputting space after tabbing
+    rl_getc_function = getc;
+    rl_catch_signals = 0;
 
     while (!get_exit_flag())
     {

--- a/bitlab/src/file.c
+++ b/bitlab/src/file.c
@@ -1,0 +1,57 @@
+#include "file.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+void read_file(const char* filename, char** buffer, size_t* size)
+{
+    FILE* file = fopen(filename, "r");
+    if (file == NULL)
+    {
+        *buffer = NULL;
+        *size = 0;
+        return;
+    }
+
+    fseek(file, 0, SEEK_END);
+    *size = ftell(file);
+    rewind(file);
+
+    *buffer = (char*)malloc(*size + 1);
+    if (*buffer == NULL)
+    {
+        *size = 0;
+        fclose(file);
+        return;
+    }
+
+    fread(*buffer, 1, *size, file);
+    (*buffer)[*size] = '\0';
+
+    fclose(file);
+}
+
+void write_file(const char* filename, const char* buffer, size_t size)
+{
+    FILE* file = fopen(filename, "w");
+    if (file == NULL)
+        return;
+
+    fwrite(buffer, 1, size, file);
+
+    fclose(file);
+}
+
+void append_file(const char* filename, const char* buffer, size_t size)
+{
+    FILE* file = fopen(filename, "a");
+    if (file == NULL)
+        return;
+
+    fwrite(buffer, 1, size, file);
+
+    fclose(file);
+}

--- a/bitlab/src/ip.c
+++ b/bitlab/src/ip.c
@@ -1,0 +1,90 @@
+#include "ip.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "utils.h"
+
+void get_local_ip_address(char* ip_address)
+{
+    FILE* file = popen("hostname -I", "r");
+    if (file == NULL)
+    {
+        strcpy(ip_address, " ");
+        return;
+    }
+    char buffer[256];
+    if (fgets(buffer, sizeof(buffer), file) == NULL)
+    {
+        strcpy(ip_address, " ");
+        pclose(file);
+        return;
+    }
+    pclose(file);
+    char* newline = strchr(buffer, '\n');
+    if (newline != NULL)
+        *newline = '\0';
+    strcpy(ip_address, buffer);
+}
+
+void get_remote_ip_address(char* ip_address)
+{
+    FILE* file = popen("curl -s ifconfig.me", "r");
+    if (file == NULL)
+    {
+        strcpy(ip_address, " ");
+        return;
+    }
+    char buffer[256];
+    if (fgets(buffer, sizeof(buffer), file) == NULL)
+    {
+        strcpy(ip_address, " ");
+        pclose(file);
+        return;
+    }
+    pclose(file);
+    char* newline = strchr(buffer, '\n');
+    if (newline != NULL)
+        *newline = '\0';
+    strcpy(ip_address, buffer);
+}
+
+void get_ip_of_url(const char* url, char* ip_address)
+{
+    char command[256];
+    snprintf(command, sizeof(command), "dig +short %s", url);
+    FILE* file = popen(command, "r");
+    if (file == NULL)
+    {
+        strcpy(ip_address, " ");
+        return;
+    }
+    char buffer[256];
+    if (fgets(buffer, sizeof(buffer), file) == NULL)
+    {
+        strcpy(ip_address, " ");
+        pclose(file);
+        return;
+    }
+    pclose(file);
+    char* newline = strchr(buffer, '\n');
+    if (newline != NULL)
+        *newline = '\0';
+    if (is_in_private_network(buffer))
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Searching remote of %s: fetched IP address %s is in the private network", url, buffer);
+    strcpy(ip_address, buffer);
+}
+
+int is_in_private_network(const char* ip_address)
+{
+    if (ip_address == NULL)
+        return 0;
+    if (strstr(ip_address, "192.168.") == ip_address)
+        return 1;
+    else if (strstr(ip_address, "10.") == ip_address)
+        return 1;
+    else if (strstr(ip_address, "172.") == ip_address)
+        return 1;
+    return 0;
+}

--- a/bitlab/src/ip.c
+++ b/bitlab/src/ip.c
@@ -50,41 +50,81 @@ void get_remote_ip_address(char* ip_address)
     strcpy(ip_address, buffer);
 }
 
-void get_ip_of_url(const char* url, char* ip_address)
+void get_ip_of_address(const char* addr, char* ip_address)
 {
     char command[256];
-    snprintf(command, sizeof(command), "dig +short %s", url);
-    FILE* file = popen(command, "r");
-    if (file == NULL)
-    {
-        strcpy(ip_address, " ");
-        return;
-    }
     char buffer[256];
-    if (fgets(buffer, sizeof(buffer), file) == NULL)
+    char current_addr[240];
+    strncpy(current_addr, addr, sizeof(current_addr) - 1);
+    current_addr[sizeof(current_addr) - 1] = '\0';
+
+    while (1)
     {
-        strcpy(ip_address, " ");
+        snprintf(command, sizeof(command), "dig +short %s", current_addr);
+
+        FILE* file = popen(command, "r");
+        if (file == NULL)
+        {
+            strcpy(ip_address, " ");
+            return;
+        }
+
+        if (fgets(buffer, sizeof(buffer), file) == NULL)
+        {
+            strcpy(ip_address, " ");
+            pclose(file);
+            return;
+        }
         pclose(file);
-        return;
+
+        char* newline = strchr(buffer, '\n');
+        if (newline != NULL)
+            *newline = '\0';
+
+        if (is_numeric_address(buffer))
+        {
+            if (is_in_private_network(buffer))
+                log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Searching remote of %s: fetched IP address %s is in the private network", addr, buffer);
+
+            strcpy(ip_address, buffer);
+            return;
+        }
+        strncpy(current_addr, buffer, sizeof(current_addr) - 1);
+        current_addr[sizeof(current_addr) - 1] = '\0';
     }
-    pclose(file);
-    char* newline = strchr(buffer, '\n');
-    if (newline != NULL)
-        *newline = '\0';
-    if (is_in_private_network(buffer))
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Searching remote of %s: fetched IP address %s is in the private network", url, buffer);
-    strcpy(ip_address, buffer);
 }
 
 int is_in_private_network(const char* ip_address)
 {
+    unsigned int b1, b2, b3, b4;
     if (ip_address == NULL)
         return 0;
-    if (strstr(ip_address, "192.168.") == ip_address)
-        return 1;
-    else if (strstr(ip_address, "10.") == ip_address)
-        return 1;
-    else if (strstr(ip_address, "172.") == ip_address)
+    if (sscanf(ip_address, "%u.%u.%u.%u", &b1, &b2, &b3, &b4) != 4)
+        return 0;
+    if ((b1 == 192 && b2 == 168) ||
+        (b1 == 10) ||
+        (b1 == 172 && b2 >= 16 && b2 <= 31))
         return 1;
     return 0;
+}
+
+int is_numeric_address(const char* ip_address)
+{
+    if (ip_address == NULL)
+        return 0;
+    for (size_t i = 0; i < strlen(ip_address); ++i)
+    {
+        if (ip_address[i] != '.' && (ip_address[i] < '0' || ip_address[i] > '9'))
+            return 0;
+    }
+    return 1;
+}
+
+int is_valid_domain_address(const char* ip_address)
+{
+    if (ip_address == NULL)
+        return 0;
+    if (strstr(ip_address, ".") == NULL)
+        return 0;
+    return 1;
 }

--- a/bitlab/src/log.c
+++ b/bitlab/src/log.c
@@ -14,8 +14,6 @@
 #include "utils.h"
 
 static struct loggers logs = { PTHREAD_MUTEX_INITIALIZER, {NULL}, 0 };
-int fileno(FILE* __stream);
-void usleep(unsigned int usec);
 
 static const char* logs_dir = NULL;
 

--- a/bitlab/src/log.c
+++ b/bitlab/src/log.c
@@ -47,7 +47,7 @@ void init_logging(const char* filename)
         }
     }
 
-    char full_path[256];
+    char full_path[BUFFER_SIZE];
     snprintf(full_path, sizeof(full_path), "%s/%s", logs_dir, filename);
 
     pthread_mutex_lock(&logs.log_mutex);
@@ -82,7 +82,7 @@ void init_logging(const char* filename)
 
 void log_message(log_level level, const char* filename, const char* source_file, const char* format, ...)
 {
-    char full_path[256];
+    char full_path[BUFFER_SIZE];
     snprintf(full_path, sizeof(full_path), "%s/%s", logs_dir, filename);
 
     pthread_mutex_lock(&logs.log_mutex);

--- a/bitlab/src/peer_discovery.c
+++ b/bitlab/src/peer_discovery.c
@@ -32,7 +32,10 @@ void* handle_peer_discovery(void* arg)
                 peer_count++;
             }
             if (peer_count > 0)
+            {
+                log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Peer discovery succeeded: found %d peers", peer_count);
                 finish_peer_discovery_progress(true);
+            }
             else
             {
                 log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery failed: no peers found");

--- a/bitlab/src/peer_discovery.c
+++ b/bitlab/src/peer_discovery.c
@@ -1,40 +1,115 @@
 #include "peer_discovery.h"
 
 #include <string.h>
+#include <stdint.h>
+#include <netinet/in.h>
+#include <pthread.h>
 
+#include "peer_queue.h"
 #include "state.h"
 #include "utils.h"
 #include "cli.h"
 #include "ip.h"
+
+static const char* dns_seeds[] =
+{
+    "seed.bitcoin.sipa.be.",
+    "seed.btc.petertodd.org.",
+    "dnsseed.emzy.de.",
+    NULL
+};
+
+static const char* hardcoded_peers[] =
+{
+    "23.84.108.213:8333",
+    "87.207.45.218:8333",
+    "35.207.115.204:8333",
+    "65.108.202.25:8333",
+    NULL
+};
 
 void* handle_peer_discovery(void* arg)
 {
     usleep(1000000); // 1 s
     while (!get_exit_flag())
     {
-        if (get_peer_discovery())
+        if (get_peer_discovery() && !get_peer_discovery_in_progress() && !get_peer_discovery_succeeded())
         {
             start_peer_discovery_progress();
-            char ip_address[BUFFER_SIZE];
-            lookup_address("seed.bitcoin.sipa.be.", ip_address);
-            char* token = strtok(ip_address, " ");
             int peer_count = 0;
-            while (token != NULL && *token != '\0')
+            bool search = false;
+
+            if (get_peer_discovery_hardcoded_seeds())
             {
-                if (strcmp(token, "0.0.0.0") == 0)
+                // query hardcoded seeds
+                search = true;
+                for (int i = 0; hardcoded_peers[i] != NULL; ++i)
                 {
-                    log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery failed: resolved IP address is 0.0.0.0");
-                    finish_peer_discovery_progress(false);
-                    break;
+                    add_peer_to_queue(hardcoded_peers[i], 0);
+                    guarded_print_line("Added hardcoded peer: %s", hardcoded_peers[i]);
+                    peer_count++;
                 }
-                guarded_print_line("Found peer: %s", token);
-                token = strtok(NULL, " ");
-                peer_count++;
             }
+            else if (get_peer_discovery_dns_lookup())
+            {
+                // query DNS seeds
+                search = true;
+
+                if (get_peer_discovery_dns_domain() == NULL)
+                {
+                    for (int i = 0; dns_seeds[i] != NULL; ++i)
+                    {
+                        char ip_address[BUFFER_SIZE];
+                        lookup_address(dns_seeds[i], ip_address);
+                        char* token = strtok(ip_address, " ");
+                        while (token != NULL && *token != '\0')
+                        {
+                            if (strcmp(token, "0.0.0.0") == 0)
+                            {
+                                log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Invalid IP from DNS seed: %s", dns_seeds[i]);
+                                break;
+                            }
+                            add_peer_to_queue(token, 8333);
+                            token = strtok(NULL, " ");
+                            peer_count++;
+                        }
+                    }
+                }
+                else
+                {
+                    char ip_address[BUFFER_SIZE];
+                    lookup_address(get_peer_discovery_dns_domain(), ip_address);
+                    char* token = strtok(ip_address, " ");
+                    while (token != NULL && *token != '\0')
+                    {
+                        if (strcmp(token, "0.0.0.0") == 0)
+                        {
+                            log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Invalid IP from DNS seed: %s", get_peer_discovery_dns_domain());
+                            break;
+                        }
+                        add_peer_to_queue(token, 8333);
+                        token = strtok(NULL, " ");
+                        peer_count++;
+                    }
+                }
+            }
+            else
+            {
+                log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery operation or no valid state set");
+                finish_peer_discovery_progress(false);
+            }
+
+            // [ ] Implement peer processing using the Bitcoin P2P protocol
+
             if (peer_count > 0)
             {
                 log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Peer discovery succeeded: found %d peers", peer_count);
                 finish_peer_discovery_progress(true);
+            }
+            else if (!search)
+            {
+                log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery failed: no valid state set");
+                finish_peer_discovery_progress(false);
             }
             else
             {

--- a/bitlab/src/peer_discovery.c
+++ b/bitlab/src/peer_discovery.c
@@ -1,8 +1,11 @@
 #include "peer_discovery.h"
 
+#include <string.h>
+
 #include "state.h"
 #include "utils.h"
 #include "cli.h"
+#include "ip.h"
 
 void* handle_peer_discovery(void* arg)
 {
@@ -11,7 +14,30 @@ void* handle_peer_discovery(void* arg)
     {
         if (get_peer_discovery())
         {
-            // peer discovery logic
+            start_peer_discovery_progress();
+            char ip_address[BUFFER_SIZE];
+            lookup_address("seed.bitcoin.sipa.be.", ip_address);
+            char* token = strtok(ip_address, " ");
+            int peer_count = 0;
+            while (token != NULL && *token != '\0')
+            {
+                if (strcmp(token, "0.0.0.0") == 0)
+                {
+                    log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery failed: resolved IP address is 0.0.0.0");
+                    finish_peer_discovery_progress(false);
+                    break;
+                }
+                guarded_print_line("Found peer: %s", token);
+                token = strtok(NULL, " ");
+                peer_count++;
+            }
+            if (peer_count > 0)
+                finish_peer_discovery_progress(true);
+            else
+            {
+                log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Peer discovery failed: no peers found");
+                finish_peer_discovery_progress(false);
+            }
         }
         usleep(100000); // 100 ms
     }

--- a/bitlab/src/peer_discovery.c
+++ b/bitlab/src/peer_discovery.c
@@ -1,0 +1,21 @@
+#include "peer_discovery.h"
+
+#include "state.h"
+#include "utils.h"
+#include "cli.h"
+
+void* handle_peer_discovery(void* arg)
+{
+    usleep(1000000); // 1 s
+    while (!get_exit_flag())
+    {
+        if (get_peer_discovery())
+        {
+            // peer discovery logic
+        }
+        usleep(100000); // 100 ms
+    }
+    if (arg) {} // dummy code to avoid unused parameter warning
+    log_message(LOG_INFO, BITLAB_LOG, __FILE__, "Exiting peer discovery thread");
+    pthread_exit(NULL);
+}

--- a/bitlab/src/peer_queue.c
+++ b/bitlab/src/peer_queue.c
@@ -1,0 +1,93 @@
+#include "peer_queue.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "utils.h"
+
+static Peer peer_queue[MAX_PEERS];
+static int peer_queue_start = 0;
+static int peer_queue_end = 0;
+static pthread_mutex_t peer_queue_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void add_peer_to_queue(const char* ip, int port)
+{
+    pthread_mutex_lock(&peer_queue_mutex);
+    if ((peer_queue_end + 1) % MAX_PEERS == peer_queue_start)
+    {
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer queue is full, cannot add peer: %s:%d", ip, port);
+        pthread_mutex_unlock(&peer_queue_mutex);
+        return;
+    }
+
+    if (port == 0)
+    {
+        char* colon_pos = strrchr(ip, ':');
+        if (colon_pos != NULL)
+        {
+            port = atoi(colon_pos + 1);
+            strncpy(peer_queue[peer_queue_end].ip, ip, colon_pos - ip);
+            peer_queue[peer_queue_end].ip[colon_pos - ip] = '\0';
+        }
+        else
+        {
+            log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Invalid IP format, cannot extract port: %s", ip);
+            pthread_mutex_unlock(&peer_queue_mutex);
+            return;
+        }
+    }
+    else
+    {
+        strncpy(peer_queue[peer_queue_end].ip, ip, sizeof(peer_queue[peer_queue_end].ip));
+    }
+
+    peer_queue[peer_queue_end].port = port;
+    peer_queue_end = (peer_queue_end + 1) % MAX_PEERS;
+    pthread_mutex_unlock(&peer_queue_mutex);
+}
+
+bool is_peer_queue_empty()
+{
+    pthread_mutex_lock(&peer_queue_mutex);
+    bool empty = (peer_queue_start == peer_queue_end);
+    pthread_mutex_unlock(&peer_queue_mutex);
+    return empty;
+}
+
+bool get_peer_from_queue(char* buffer, size_t buffer_size)
+{
+    pthread_mutex_lock(&peer_queue_mutex);
+    if (peer_queue_start == peer_queue_end)
+    {
+        pthread_mutex_unlock(&peer_queue_mutex);
+        return false;
+    }
+    snprintf(buffer, buffer_size, "%s:%d", peer_queue[peer_queue_start].ip, peer_queue[peer_queue_start].port);
+    peer_queue_start = (peer_queue_start + 1) % MAX_PEERS;
+    pthread_mutex_unlock(&peer_queue_mutex);
+    return true;
+}
+
+void clear_peer_queue()
+{
+    pthread_mutex_lock(&peer_queue_mutex);
+    peer_queue_start = 0;
+    peer_queue_end = 0;
+    pthread_mutex_unlock(&peer_queue_mutex);
+}
+
+void print_peer_queue()
+{
+    pthread_mutex_lock(&peer_queue_mutex);
+    if (peer_queue_start == peer_queue_end)
+    {
+        guarded_print_line("Peer queue is empty");
+        pthread_mutex_unlock(&peer_queue_mutex);
+        return;
+    }
+    for (int i = peer_queue_start; i != peer_queue_end; i = (i + 1) % MAX_PEERS)
+        guarded_print_line("%s:%d", peer_queue[i].ip, peer_queue[i].port);
+    pthread_mutex_unlock(&peer_queue_mutex);
+}

--- a/bitlab/src/state.c
+++ b/bitlab/src/state.c
@@ -28,12 +28,12 @@ program_state state = { 0, 0, 0, 0, PTHREAD_MUTEX_INITIALIZER };
  */
 program_operation operation = { false, false, false, PTHREAD_MUTEX_INITIALIZER };
 
-void init_program_state(program_state* state)
+void init_program_state()
 {
-    state->pid = getpid();
-    state->start_time = time(NULL);
-    state->exit_flag = 0;
-    pthread_mutex_init(&state->exit_flag_mutex, NULL);
+    state.pid = getpid();
+    state.start_time = time(NULL);
+    state.exit_flag = 0;
+    pthread_mutex_init(&state.exit_flag_mutex, NULL);
 
     if (strcmp(getenv("USER"), "root") == 0)
         log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Running as root is not recommended");

--- a/bitlab/src/state.c
+++ b/bitlab/src/state.c
@@ -1,22 +1,127 @@
 #include "state.h"
 
+#include <stdbool.h>
 #include <signal.h>
+#include <pthread.h>
+#include <string.h>
 
-volatile program_state state = { 0, 0, 0 };
+#include "utils.h"
 
-void init_program_state(volatile program_state* state)
+/**
+ * The program state structure used to store the state of the program. Only accessible in state.c directly, otherwise functions should be used.
+ *
+ * @param pid The process ID of the program.
+ * @param start_time The start time of the program.
+ * @param started_with_parameters The flag to indicate if the program started with CLI parameters.
+ * @param exit_flag The exit flag of the program.
+ * @param exit_flag_mutex The mutex to protect the exit flag.
+ */
+program_state state = { 0, 0, 0, 0, PTHREAD_MUTEX_INITIALIZER };
+
+/**
+ * The program operation structure used to store the operation of the program. Only accessible in state.c directly, otherwise functions should be used.
+ *
+ * @param peer_discovery The peer discovery operation of the program.
+ * @param peer_discovery_in_progress The peer discovery operation in progress.
+ * @param mutex The mutex to protect the operation.
+ */
+program_operation operation = { false, false, PTHREAD_MUTEX_INITIALIZER };
+
+void init_program_state(program_state* state)
 {
     state->pid = getpid();
     state->start_time = time(NULL);
     state->exit_flag = 0;
+    pthread_mutex_init(&state->exit_flag_mutex, NULL);
+
+    if (strcmp(getenv("USER"), "root") == 0)
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Running as root is not recommended");
 }
 
-void set_exit_flag(volatile program_state* state, sig_atomic_t flag)
+void set_exit_flag(volatile sig_atomic_t flag)
 {
-    state->exit_flag = flag;
+    pthread_mutex_lock(&state.exit_flag_mutex);
+    state.exit_flag = flag;
+    pthread_mutex_unlock(&state.exit_flag_mutex);
 }
 
-sig_atomic_t get_exit_flag(volatile program_state* state)
+sig_atomic_t get_exit_flag()
 {
-    return state->exit_flag;
+    pthread_mutex_lock(&state.exit_flag_mutex);
+    sig_atomic_t flag = state.exit_flag;
+    pthread_mutex_unlock(&state.exit_flag_mutex);
+    return flag;
+}
+
+void mark_started_with_parameters()
+{
+    pthread_mutex_lock(&state.exit_flag_mutex);
+    state.started_with_parameters = true;
+    pthread_mutex_unlock(&state.exit_flag_mutex);
+}
+
+void destroy_program_state(program_state* state)
+{
+    pthread_mutex_destroy(&state->exit_flag_mutex);
+}
+
+int init_program_operation(program_operation* operation)
+{
+    pthread_mutex_init(&operation->operation_mutex, NULL);
+    operation->peer_discovery = false;
+    return 0;
+}
+
+int set_peer_discovery(bool value)
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    if (operation.peer_discovery && operation.peer_discovery_in_progress && !value)
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer discovery operation in progress, cannot stop. Did you mean force_stop_peer_discovery?");
+    else if (!operation.peer_discovery && !operation.peer_discovery_in_progress && value)
+    {
+        operation.peer_discovery = true;
+        operation.peer_discovery_in_progress = true;
+    }
+    else
+        operation.peer_discovery = value;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return 0;
+}
+
+int force_stop_peer_discovery()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    operation.peer_discovery = false;
+    operation.peer_discovery_in_progress = false;
+    log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer discovery operation force-stopped");
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return 0;
+}
+
+bool get_peer_discovery()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    bool value = operation.peer_discovery && operation.peer_discovery_in_progress;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+void destroy_program_operation(program_operation* operation)
+{
+    pthread_mutex_destroy(&operation->operation_mutex);
+}
+
+int get_pid()
+{
+    return state.pid;
+}
+
+time_t get_start_time()
+{
+    return state.start_time;
+}
+
+int get_elapsed_time()
+{
+    return time(NULL) - state.start_time;
 }

--- a/bitlab/src/state.c
+++ b/bitlab/src/state.c
@@ -16,7 +16,14 @@
  * @param exit_flag The exit flag of the program.
  * @param exit_flag_mutex The mutex to protect the exit flag.
  */
-program_state state = { 0, 0, 0, 0, PTHREAD_MUTEX_INITIALIZER };
+program_state state =
+{
+    0,
+    0, 
+    0,
+    0,
+    PTHREAD_MUTEX_INITIALIZER
+};
 
 /**
  * The program operation structure used to store the operation of the program. Only accessible in state.c directly, otherwise functions should be used.
@@ -24,9 +31,23 @@ program_state state = { 0, 0, 0, 0, PTHREAD_MUTEX_INITIALIZER };
  * @param peer_discovery The peer discovery operation of the program.
  * @param peer_discovery_in_progress The peer discovery operation in progress.
  * @param peer_discovery_succeeded The peer discovery operation succeeded.
+ * @param peer_discovery_daemon The peer discovery operation as a daemon.
+ * @param peer_discovery_hardcoded_seeds The peer discovery operation with hardcoded seeds.
+ * @param peer_discovery_dns_lookup The peer discovery operation with DNS lookup.
+ * @param peer_discovery_dns_domain The peer discovery DNS domain field for custom DNS lookup.
  * @param mutex The mutex to protect the operation.
  */
-program_operation operation = { false, false, false, PTHREAD_MUTEX_INITIALIZER };
+program_operation operation =
+{
+    false,
+    false,
+    false,
+    PEER_DISCOVERY_DEFAULT_DAEMON,
+    PEER_DISCOVERY_DEFAULT_HARDCODED_SEEDS,
+    PEER_DISCOVERY_DEFAULT_HARDCODED_SEEDS,
+    NULL,
+    PTHREAD_MUTEX_INITIALIZER
+};
 
 void init_program_state()
 {
@@ -37,6 +58,16 @@ void init_program_state()
 
     if (strcmp(getenv("USER"), "root") == 0)
         log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Running as root is not recommended");
+}
+
+void print_program_state()
+{
+    guarded_print_line("Program uptime: %d", get_elapsed_time());
+    guarded_print_line("Program PID: %d", state.pid);
+    if (state.started_with_parameters)
+        guarded_print_line("Program started with CLI parameters");
+    else
+        guarded_print_line("Program started without CLI parameters");
 }
 
 void set_exit_flag(volatile sig_atomic_t flag)
@@ -61,15 +92,15 @@ void mark_started_with_parameters()
     pthread_mutex_unlock(&state.exit_flag_mutex);
 }
 
-void destroy_program_state(program_state* state)
+void destroy_program_state()
 {
-    pthread_mutex_destroy(&state->exit_flag_mutex);
+    pthread_mutex_destroy(&state.exit_flag_mutex);
 }
 
-int init_program_operation(program_operation* operation)
+int init_program_operation()
 {
-    pthread_mutex_init(&operation->operation_mutex, NULL);
-    operation->peer_discovery = false;
+    pthread_mutex_init(&operation.operation_mutex, NULL);
+    operation.peer_discovery = false;
     return 0;
 }
 
@@ -86,31 +117,34 @@ void start_peer_discovery_progress()
 void finish_peer_discovery_progress(bool succeeded)
 {
     pthread_mutex_lock(&operation.operation_mutex);
-    operation.peer_discovery = false;
     operation.peer_discovery_in_progress = false;
     operation.peer_discovery_succeeded = succeeded;
     pthread_mutex_unlock(&operation.operation_mutex);
 }
 
-int set_peer_discovery(bool value)
+bool set_peer_discovery(bool value)
 {
     pthread_mutex_lock(&operation.operation_mutex);
     if (operation.peer_discovery && operation.peer_discovery_in_progress && !value)
+    {
         log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer discovery operation in progress, cannot stop. Did you mean force_stop_peer_discovery?");
+        pthread_mutex_unlock(&operation.operation_mutex);
+        return false;
+    }
     else
         operation.peer_discovery = value;
     pthread_mutex_unlock(&operation.operation_mutex);
-    return 0;
+    return true;
 }
 
-int force_stop_peer_discovery()
+bool force_stop_peer_discovery()
 {
     pthread_mutex_lock(&operation.operation_mutex);
     operation.peer_discovery = false;
     operation.peer_discovery_in_progress = false;
     log_message(LOG_WARN, BITLAB_LOG, __FILE__, "Peer discovery operation force-stopped");
     pthread_mutex_unlock(&operation.operation_mutex);
-    return 0;
+    return true;
 }
 
 bool get_peer_discovery()
@@ -129,9 +163,90 @@ bool get_peer_discovery_in_progress()
     return value;
 }
 
-void destroy_program_operation(program_operation* operation)
+bool get_peer_discovery_succeeded()
 {
-    pthread_mutex_destroy(&operation->operation_mutex);
+    pthread_mutex_lock(&operation.operation_mutex);
+    bool value = operation.peer_discovery_succeeded;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+bool set_peer_discovery_daemon(bool value)
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    operation.peer_discovery_daemon = value;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return true;
+}
+
+bool set_peer_discovery_hardcoded_seeds(bool value)
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    operation.peer_discovery_hardcoded_seeds = value;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return true;
+}
+
+bool set_peer_discovery_dns_lookup(bool value)
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    operation.peer_discovery_dns_lookup = value;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return true;
+}
+
+bool get_peer_discovery_daemon()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    bool value = operation.peer_discovery_daemon;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+bool get_peer_discovery_hardcoded_seeds()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    bool value = operation.peer_discovery_hardcoded_seeds;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+bool get_peer_discovery_dns_lookup()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    bool value = operation.peer_discovery_dns_lookup;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+bool set_peer_discovery_dns_domain(const char* domain)
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    if (operation.peer_discovery_dns_domain != NULL)
+        free(operation.peer_discovery_dns_domain);
+    operation.peer_discovery_dns_domain = (char*)malloc(strlen(domain) + 1);
+    if (operation.peer_discovery_dns_domain == NULL)
+    {
+        log_message(LOG_ERROR, BITLAB_LOG, __FILE__, "Failed to allocate memory for peer discovery DNS domain");
+        pthread_mutex_unlock(&operation.operation_mutex);
+        return false;
+    }
+    strcpy(operation.peer_discovery_dns_domain, domain);
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return true;
+}
+
+const char* get_peer_discovery_dns_domain()
+{
+    pthread_mutex_lock(&operation.operation_mutex);
+    const char* value = operation.peer_discovery_dns_domain;
+    pthread_mutex_unlock(&operation.operation_mutex);
+    return value;
+}
+
+void destroy_program_operation()
+{
+    pthread_mutex_destroy(&operation.operation_mutex);
 }
 
 int get_pid()

--- a/bitlab/src/thread.c
+++ b/bitlab/src/thread.c
@@ -1,0 +1,16 @@
+#include "thread.h"
+
+#include <pthread.h>
+#include <errno.h>
+#include <string.h>
+
+#include "utils.h"
+
+pthread_t thread_runner(void* (*start_routine)(void*), void* arg)
+{
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, start_routine, arg) != 0)
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "%s thread creation failed: %s", __func__, strerror(errno));
+    log_message(LOG_INFO, BITLAB_LOG, __FILE__, "%s thread started", __func__);
+    return thread;
+}

--- a/bitlab/src/thread.c
+++ b/bitlab/src/thread.c
@@ -6,11 +6,11 @@
 
 #include "utils.h"
 
-pthread_t thread_runner(void* (*start_routine)(void*), void* arg)
+pthread_t thread_runner(void* (*start_routine)(void*), const char* name, void* arg)
 {
     pthread_t thread;
     if (pthread_create(&thread, NULL, start_routine, arg) != 0)
-        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "%s thread creation failed: %s", __func__, strerror(errno));
-    log_message(LOG_INFO, BITLAB_LOG, __FILE__, "%s thread started", __func__);
+        log_message(LOG_WARN, BITLAB_LOG, __FILE__, "%s thread creation failed: %s", name, strerror(errno));
+    log_message(LOG_INFO, BITLAB_LOG, __FILE__, "%s thread started", name);
     return thread;
 }

--- a/bitlab/src/utils.c
+++ b/bitlab/src/utils.c
@@ -5,12 +5,10 @@
 #include <stdarg.h>
 #include <time.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
 #include <sys/file.h>
 #include <sys/stat.h>
-
-struct tm* localtime_r(const time_t* timer, struct tm* buf);
-void flockfile(FILE* filehandle);
-void funlockfile(FILE* file);
 
 void get_timestamp(char* buffer, size_t buffer_size)
 {
@@ -30,7 +28,7 @@ void get_formatted_timestamp(char* buffer, size_t buffer_size)
 
 void clear_cli()
 {
-    guarded_printf("\033[H\033[J");
+    guarded_print("\033[H\033[J");
 }
 
 int init_config_dir()
@@ -50,12 +48,23 @@ int init_config_dir()
     return 0;
 }
 
-void guarded_printf(const char* format, ...)
+void guarded_print(const char* format, ...)
 {
     flockfile(stdout);
     va_list args;
     va_start(args, format);
     vprintf(format, args);
     va_end(args);
+    funlockfile(stdout);
+}
+
+void guarded_print_line(const char* format, ...)
+{
+    flockfile(stdout);
+    va_list args;
+    va_start(args, format);
+    vprintf(format, args);
+    va_end(args);
+    printf("\n");
     funlockfile(stdout);
 }


### PR DESCRIPTION
# Peer discovery

This is the first PR concerning peer discovery feature.

Commands modified:
- [x] peerdiscovery - New command allowing starting and connecting to the results of the peer discovery thread
- [x] info - New command provides useful information about program state and concurrent actions
- [x] help - Modified command provides three columns: command, parameters, description

Program finds IPs of active Bitcoin peers. Next PR iteration will allow for peer connection and recursive peer discovery.